### PR TITLE
feat(ioconfig): add earlyMessageRejectPeriod

### DIFF
--- a/io_config.go
+++ b/io_config.go
@@ -3,17 +3,19 @@ package godruid
 type IOConfig interface{}
 
 type ioConfigKafka struct {
-	Type                      string              `json:"type"`
-	ConsumerProperties        *ConsumerProperties `json:"consumerProperties"`
-	Topic                     string              `json:"topic"`
-	LatestMessageRejectPeriod string              `json:"lateMessageRejectionPeriod"`
+	Type                        string              `json:"type"`
+	ConsumerProperties          *ConsumerProperties `json:"consumerProperties"`
+	Topic                       string              `json:"topic"`
+	LatestMessageRejectPeriod   string              `json:"lateMessageRejectionPeriod,omitempty"`
+	EarlyMessageRejectionPeriod string              `json:"earlyMessageRejectionPeriod,omitempty"`
 }
 
-func IOConfigKafka(topic, latestMessageRejectPeriod, bootstrapServers, saslMechanism, securityProtocal, sasLJAASConfig string) IOConfig {
+func IOConfigKafka(topic, latestMessageRejectPeriod, earlyMessageRejectionPeriod, bootstrapServers, saslMechanism, securityProtocal, sasLJAASConfig string) IOConfig {
 	return &ioConfigKafka{
-		Type:                      "kafka",
-		Topic:                     topic,
-		LatestMessageRejectPeriod: latestMessageRejectPeriod,
+		Type:                        "kafka",
+		Topic:                       topic,
+		LatestMessageRejectPeriod:   latestMessageRejectPeriod,
+		EarlyMessageRejectionPeriod: earlyMessageRejectionPeriod,
 		ConsumerProperties: &ConsumerProperties{
 			BootstrapServers: bootstrapServers,
 			SASLMechanism:    saslMechanism,


### PR DESCRIPTION
> to reject messages with timestamps later than this period after the task reached its taskDuration

https://druid.apache.org/docs/latest/development/extensions-core/kafka-ingestion.html#kafkasupervisorioconfig